### PR TITLE
Fix docs-site deployment by mapping port 80 in docker-compose

### DIFF
--- a/docs-site/docker-compose.yml
+++ b/docs-site/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-    expose:
-      - "80"
+    ports:
+      - "80:80"
     environment:
       - NODE_ENV=production
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Corrects the Docker Compose configuration for the docs-site service
- Changes from using `expose` to `ports` to properly map port 80
- Ensures the docs-site is accessible externally on port 80

## Changes

### Docker Configuration
- Updated `docs-site/docker-compose.yml`:
  - Replaced `expose: - "80"` with `ports: - "80:80"` under the docs-site service
  - This change maps the container's port 80 to the host's port 80, enabling external access

## Test plan
- [ ] Deploy the docs-site using the updated docker-compose configuration
- [ ] Verify that the site is accessible via port 80 externally
- [ ] Confirm no other services are affected by this port mapping change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6113129b-a9aa-4115-a7f2-fee2809b53b2