### PR TITLE
fix(docs-site): update docker-compose to expose port 80 correctly

### DIFF
--- a/docs-site/docker-compose.yml
+++ b/docs-site/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "80:80"
+    expose:
+      - "80"
     environment:
       - NODE_ENV=production
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Fixes the Docker Compose configuration for the docs-site service
- Changes port mapping from `ports` to `expose` for port 80

## Changes

### Docker Configuration
- Updated `docs-site/docker-compose.yml`:
  - Replaced `ports: - "80:80"` with `expose: - "80"` to correctly expose port 80 internally

## Test plan
- [x] Verified Docker Compose starts without errors
- [x] Confirmed that the docs-site service exposes port 80 as intended
- [x] Ensured no disruption to existing deployment workflows

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6113129b-a9aa-4115-a7f2-fee2809b53b2