### PR TITLE
Fix docs-site loading by correcting docker-compose port mapping

### DIFF
--- a/docs-site/docker-compose.yml
+++ b/docs-site/docker-compose.yml
@@ -1,12 +1,10 @@
-version: "3.8"
-
 services:
   docs:
     build: 
       context: .
       dockerfile: Dockerfile
-    expose:
-      - "80"
+    ports:
+      - "3001:80"
     environment:
       - NODE_ENV=production
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Fixes the docs-site loading error by updating the docker-compose configuration
- Changes the service port mapping from `expose` to `ports` with explicit host-to-container port binding

## Changes

### Docker Configuration
- Updated `docs-site/docker-compose.yml`:
  - Removed `expose: 80` which only exposes the port to linked services
  - Added `ports: - "3001:80"` to map container port 80 to host port 3001, enabling external access

## Test plan
- [x] Verified that the docs-site service starts correctly with the new port mapping
- [x] Confirmed that the docs-site is accessible via `localhost:3001`
- [x] Ensured no other services are affected by this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3686bd16-d083-42b7-b90d-0baa995d2857